### PR TITLE
Simplify nested `if let` statement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -125,17 +125,13 @@ fn parse_query(query: &str) -> Result<TimeRange, String> {
         .collect::<HashMap<String, String>>();
 
     let before = args.get("before").map(|value| value.parse::<i64>());
-    if let Some(ref result) = before {
-        if let Err(ref error) = *result {
-            return Err(format!("Error parsing 'before': {}", error));
-        }
+    if let Some(Err(ref error)) = before {
+        return Err(format!("Error parsing 'before': {}", error));
     }
 
     let after = args.get("after").map(|value| value.parse::<i64>());
-    if let Some(ref result) = after {
-        if let Err(ref error) = *result {
-            return Err(format!("Error parsing 'after': {}", error));
-        }
+    if let Some(Err(ref error)) = after {
+        return Err(format!("Error parsing 'after': {}", error));
     }
 
     Ok(TimeRange {


### PR DESCRIPTION
I found a way to simplify two direct nested `if let` statement which is to destructure (maybe there's a better word) both `Some` and `Err` from `error`.