### PR TITLE
Remove 'static lifetime from const

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ mod schema;
 
 use models::{Message, NewMessage};
 
-const DEFAULT_DATABASE_URL: &'static str = "postgresql://postgres@localhost:5432";
+const DEFAULT_DATABASE_URL: &str = "postgresql://postgres@localhost:5432";
 
 struct Microservice;
 


### PR DESCRIPTION
`const` outside `main` are already `'static` by default.

http://rust-lang.github.io/rfcs/1623-static.html