### PR TITLE
Fix: cargo install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,6 @@ WORKDIR /var/www/microservice/
 COPY . .
 
 RUN rustc --version
-RUN cargo install
+RUN cargo install --path .
 
 CMD ["microservice"]


### PR DESCRIPTION
`cargo install` is deprecated, using `cargo install --path .` seems work